### PR TITLE
fix: Add timeout to litellm calls

### DIFF
--- a/research_agent/inno/core.py
+++ b/research_agent/inno/core.py
@@ -381,6 +381,7 @@ class MetaChain:
                 "tool_choice": agent.tool_choice,
                 "stream": stream,
                 "base_url": API_BASE_URL,
+                "timeout": 600,
             }
             NO_SENDER_MODE = False
             for not_sender_model in NOT_SUPPORT_SENDER:
@@ -425,6 +426,7 @@ class MetaChain:
                 "messages": messages,
                 "stream": stream,
                 "base_url": API_BASE_URL,
+                "timeout": 600,
             }
             completion_response = await acompletion(**create_params)
             last_message = [{"role": "assistant", "content": completion_response.choices[0].message.content}]


### PR DESCRIPTION
This change adds a 600-second timeout to the `litellm.acompletion` calls in `research_agent/inno/core.py`. This prevents premature timeouts when using slow models, such as Qwen models, which can have high latency.

600 seconds is probably too long and will stall forever perhaps with other sorts of problems, consider reducing later.