### PR TITLE
Add logging for JSON parsing errors in `extract_json_from_output`.

### DIFF
--- a/research_agent/run_infer_idea.py
+++ b/research_agent/run_infer_idea.py
@@ -22,6 +22,7 @@ import asyncio
 import argparse
 import os
 from typing import List, Dict, Any, Union
+import logging
 from research_agent.inno.logger import MetaChainLogger
 import importlib
 from research_agent.inno.environment.utils import setup_dataset
@@ -54,7 +55,8 @@ def extract_json_from_output(output_text: str) -> dict:
         try:
             return json.loads(json_str)
         except json.JSONDecodeError as e:
-            print(f"JSON解析错误: {e}")
+            logging.error(f"JSON解析错误: {e}")
+            logging.error(f"错误的JSON字符串: {json_str}")
             return {}
     return {}
 def get_args(): 

--- a/research_agent/run_infer_plan.py
+++ b/research_agent/run_infer_plan.py
@@ -21,6 +21,7 @@ import asyncio
 import argparse
 import os
 from typing import List, Dict, Any, Union
+import logging
 from research_agent.inno.logger import MetaChainLogger
 import importlib
 from research_agent.inno.environment.utils import setup_dataset
@@ -53,7 +54,8 @@ def extract_json_from_output(output_text: str) -> dict:
         try:
             return json.loads(json_str)
         except json.JSONDecodeError as e:
-            print(f"JSON解析错误: {e}")
+            logging.error(f"JSON解析错误: {e}")
+            logging.error(f"错误的JSON字符串: {json_str}")
             return {}
     return {}
 def get_args(): 


### PR DESCRIPTION
The `extract_json_from_output` function in `run_infer_plan.py` and `run_infer_idea.py` can fail with a `json.JSONDecodeError` if the input string is not valid JSON.

This change adds logging to record the malformed JSON string when a `JSONDecodeError` occurs. This will help to debug issues with malformed JSON responses from the LLM.

attempt to debug json error