### PR TITLE
Fix JSON parsing error and improve agent prompts

### DIFF
--- a/research_agent/inno/agents/inno_agent/survey_agent.py
+++ b/research_agent/inno/agents/inno_agent/survey_agent.py
@@ -47,7 +47,7 @@ WORKFLOW:
    - Formal definitions
    - Mathematical formulas
    - Key theoretical components
-4. Document your findings and transfer your findings to the `Code Survey Agent` using the `transfer_to_code_survey_agent` function. Make sure you have read these papers thoroughly.
+4. Document your findings and transfer your findings to the `Code Survey Agent` using the `transfer_to_code_survey_agent` function. Make sure you have read these papers thoroughly. YOU MUST USE THE `transfer_to_code_survey_agent` function. DO NOT use any other `transfer_...` function.
 
 REQUIREMENTS:
 - Be thorough in your analysis


### PR DESCRIPTION
This change addresses a JSON parsing error that occurred during the paper survey process. The error was caused by me calling an incorrect tool, which resulted in an invalid JSON output.

The following changes were made:

- Updated my instructions in `survey_agent.py` to be more explicit about the correct tool to use.
- Improved the `extract_json_from_output` function in `run_infer_plan.py` to be more robust by adding support for JSON in markdown code blocks.

Unclear about the agent prompt change if it will really solve the problem